### PR TITLE
name パラメータを許可しました

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::Base
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+  end
 end


### PR DESCRIPTION
Devise上で、nameパラメータが未許可だった為、ApplicationControllerにて、ストロンパラーメータを設定し、nameパラメータを許可しました。