### PR TITLE
google認証におけるセキュリティ面を強化しました

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ gem 'activerecord-session_store'
 # gem "kredis"
 gem 'omniauth', '~> 2.0'
 gem 'omniauth-google-oauth2'
+gem 'omniauth-rails_csrf_protection'
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,6 +283,9 @@ GEM
     omniauth-oauth2 (1.8.0)
       oauth2 (>= 1.4, < 3)
       omniauth (~> 2.0)
+    omniauth-rails_csrf_protection (1.0.2)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
     orm_adapter (0.5.0)
     pg (1.5.6)
     psych (5.1.2)
@@ -472,6 +475,7 @@ DEPENDENCIES
   net-protocol
   omniauth (~> 2.0)
   omniauth-google-oauth2
+  omniauth-rails_csrf_protection
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.4)

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -10,12 +10,8 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   def callback_for(provider)
-    # 先ほどuser.rbで記述したメソッド(from_omniauth)をここで使っています
-    # 'request.env["omniauth.auth"]'この中にgoogoleアカウントから取得したメールアドレスや、名前と言ったデータが含まれています
     auth = request.env["omniauth.auth"]
-    Rails.logger.debug "Omniauth data: #{auth.inspect}"
     @user = User.from_omniauth(auth)
-    Rails.logger.debug "User from omniauth: #{@user.inspect}"
 
     if @user.present?
       sign_in_and_redirect @user, event: :authentication

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -40,9 +40,9 @@
     </div>
 
     <div class="flex space-x-4 justify-center">
-      <%= link_to user_google_oauth2_omniauth_authorize_path, class: "w-1/2 py-2 px-4 border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:ring-opacity-50 flex items-center justify-center", method: :post do %>
-        <img src="https://www.svgrepo.com/show/355037/google.svg" alt="Google" class="h-5 w-5 mr-2" />
-        <span>Google</span>
+      <%= button_to user_google_oauth2_omniauth_authorize_path, method: :post, data: { turbo: false }, class: "flex items-center py-2 px-4 border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:ring-opacity-50" do %>
+        <img src="https://www.svgrepo.com/show/355037/google.svg" alt="Google" class="h-5 w-5 mr-2 inline-block" />
+        <span class="inline-block">Google</span>
       <% end %>
     </div>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -37,9 +37,9 @@
     </div>
 
     <div class="flex space-x-4 justify-center">
-      <%= link_to user_google_oauth2_omniauth_authorize_path, class: "w-1/2 py-2 px-4 border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:ring-opacity-50 flex items-center justify-center", method: :post do %>
-        <img src="https://www.svgrepo.com/show/355037/google.svg" alt="Google" class="h-5 w-5 mr-2" />
-        <span>Google</span>
+      <%= button_to user_google_oauth2_omniauth_authorize_path, method: :post, data: { turbo: false }, class: "flex items-center py-2 px-4 border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:ring-opacity-50" do %>
+        <img src="https://www.svgrepo.com/show/355037/google.svg" alt="Google" class="h-5 w-5 mr-2 inline-block" />
+        <span class="inline-block">Google</span>
       <% end %>
     </div>
 

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,3 +1,3 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
-  OmniAuth.config.allowed_request_methods = [:post, :get]
+  OmniAuth.config.allowed_request_methods = [:post]
 end


### PR DESCRIPTION
CSRF攻撃のリスクを削減する為に、gem 'omniauth-rails_csrf_protection'を導入し、また、セキュリティの観点から、OmniAuthでの認証リクエストにGETメソッドを許可しない様に設定しました。