### PR TITLE
google認証の際にパスワード入力なしでプロフィール編集が出来るようにしました

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -3,7 +3,7 @@
 class Users::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
-
+  
   # GET /resource/sign_up
   # def new
   #   super
@@ -40,6 +40,13 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # protected
 
+  def update_resource(resource, params)
+    if resource.provider == 'google_oauth2'
+      resource.update_without_password(params)
+    else
+      resource.update_with_password(params)
+    end
+  end
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_up_params
   #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -31,24 +31,28 @@
         <div class="mb-4 text-sm text-gray-700"><%= t('.currently_waiting_confirmation_for_email', email: resource.unconfirmed_email) %></div>
       <% end %>
 
-      <div class="field flex flex-col mb-4">
-        <%= f.label :password, class: "block text-sm font-medium text-gray-700" %>
-        <% if @minimum_password_length %>
-          <em class="text-xs text-gray-500"><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em>
-        <% end %>
-        <%= f.password_field :password, autocomplete: "new-password", class: "mt-1 px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm" %>
-      </div>
+      <% if current_user.provider.blank? %>
+        <div class="field flex flex-col mb-4">
+          <%= f.label :password, class: "block text-sm font-medium text-gray-700" %>
+          <% if @minimum_password_length %>
+            <em class="text-xs text-gray-500"><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em>
+          <% end %>
+          <%= f.password_field :password, autocomplete: "new-password", class: "mt-1 px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm" %>
+        </div>
 
-      <div class="field flex flex-col mb-4">
-        <%= f.label :password_confirmation, class: "block text-sm font-medium text-gray-700" %>
-        <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "mt-1 px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm" %>
-      </div>
+        <div class="field flex flex-col mb-4">
+          <%= f.label :password_confirmation, class: "block text-sm font-medium text-gray-700" %>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "mt-1 px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm" %>
+        </div>
 
-      <div class="field flex flex-col mb-4">
-        <%= f.label :current_password, class: "block text-sm font-medium text-gray-700" %> 
-        <em class="text-xs text-gray-500"><%= t('.we_need_your_current_password_to_confirm_your_changes') %></em>
-        <%= f.password_field :current_password, autocomplete: "current-password", class: "mt-1 px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm" %>
-      </div>
+        <div class="field flex flex-col mb-4">
+          <%= f.label :current_password, class: "block text-sm font-medium text-gray-700" %> 
+          <em class="text-xs text-gray-500"><%= t('.we_need_your_current_password_to_confirm_your_changes') %></em>
+          <%= f.password_field :current_password, autocomplete: "current-password", class: "mt-1 px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm" %>
+        </div>
+      <% else %>
+        <p class="text-sm text-gray-600 mb-4">Googleアカウントでログインしているため、パスワードの入力は不要です。</p>
+      <% end %>
 
       <div class="actions">
         <%= f.submit t('.update'), class: "w-full py-2 px-4 bg-secondary text-white font-bold rounded-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-indigo-500" %>
@@ -64,4 +68,5 @@
     </div>
   </div>
 </div>
+
 


### PR DESCRIPTION
コントローラーにgoogle認証でログインしている場合は、プロフィール編集の際にパスワードを必要としない旨のアクションを定義し、編集用のビューには、プロバイダーが存在するかどうかで条件分岐をし正しい編集画面を表示する様なロジックを定義しました。