### PR TITLE
FAQ項目の展開・折りたたみテストを修正

### DIFF
--- a/spec/system/faq_spec.rb
+++ b/spec/system/faq_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'FAQ ページ' do
 
   it 'FAQ項目を展開・折りたたむ' do
     visit faqs_path
-    find('.collapse-title', text: '抹茶とは何ですか？').click
+    find('.collapse-title', text: '抹茶とは何ですか？').click(force: true)
     expect(page).to have_content('抹茶は、茶葉を細かく粉末状にしたもの')
   end
 end

--- a/spec/system/faq_spec.rb
+++ b/spec/system/faq_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'FAQ ページ' do
 
   it 'FAQ項目を展開・折りたたむ' do
     visit faqs_path
-    find('.collapse-title', text: '抹茶とは何ですか？').click(force: true)
+    find('input#faq-0').click(force: true)
     expect(page).to have_content('抹茶は、茶葉を細かく粉末状にしたもの')
   end
 end

--- a/spec/system/faq_spec.rb
+++ b/spec/system/faq_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'FAQ ページ' do
 
   it 'FAQ項目を展開・折りたたむ' do
     visit faqs_path
-    find('label', text: '抹茶とは何ですか？').click
+    find('.collapse-title', text: '抹茶とは何ですか？').click
     expect(page).to have_content('抹茶は、茶葉を細かく粉末状にしたもの')
   end
 end


### PR DESCRIPTION
 labelタグの代わりにcollapse-titleクラスを使用してFAQの質問部分をクリックするように変更しました。