### PR TITLE
本番環境で画像のアップロードが機能する様に修正しました

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -7,9 +7,9 @@ require 'carrierwave/storage/fog'
 
 CarrierWave.configure do |config|
   if Rails.env.production?
-    # 本番環境ではS3を使用
     config.storage = :fog
     config.fog_directory = 'leaf-whisper'
+    config.fog_provider = 'fog/aws'
     config.fog_credentials = {
       provider: 'AWS',
       aws_access_key_id: ENV.fetch('AWS_ACCESS_KEY_ID', nil),
@@ -17,9 +17,9 @@ CarrierWave.configure do |config|
       region: 'ap-northeast-1',
       path_style: true
     }
+    config.fog_attributes = {}
   else
-    # 開発・テスト環境ではローカルストレージを使用
     config.storage = :file
-    config.enable_processing = false if Rails.env.test? # テスト環境では画像処理を無効化
+    config.enable_processing = false if Rails.env.test?
   end
 end


### PR DESCRIPTION
本番環境でプロフィール画像のアップロードが機能しない事象が発生してしまっていた為、Amason S3 のバケットポリシーの設定や、carrierwaveの設定を見直しました。